### PR TITLE
PersonalTools: Add attribute hideNewtalkNotifier + use it for Standard layout

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -603,6 +603,22 @@ applicable.
   The class (or classes) that should be assigned to the top-level html element
   of this component.
 
+* `hideNewtalkNotifier`
+  * **Deprecated.**
+  * Allowed values: Boolean (`yes`|`no`)
+  * Default: `no`
+  * Optional.
+  
+  If set the newtalk notifier will not be shown.
+
+  This attribute has no effect when used inside the
+  [NavbarHorizontal](#component-navbar-horizontal) component.
+  
+  This attribute was introduced to keep backwards compatibility. If the
+  PersonalTools component is used, it is recommended to always set this
+  attribute to *yes* and use an independent
+  [NewtalkNotifier](#component-newtalknotifier) component.
+
 #### Allowed Parent Elements:
 * [Structure](#structure)
 * [Cell](#cell)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,11 +1,34 @@
 ## Release Notes
 
+### Chameleon 1.5
+
+Released on tbd
+
+Changes:
+* Move from WMF server to GitHub: Updates of documentation, some scripts,
+  registration with [translatewiki](https://translatewiki.net)
+* Improve documentation
+* Replace [jquery-sticky](https://github.com/garand/sticky) by
+  [sticky-kit](http://leafo.net/sticky-kit/)
+* Use sticky for the navbar of the fixedhead layout
+* PersonalTools: Add attribute *hideNewtalkNotifier*
+* Standard layout: Use separate NewtalkNotifier and PersonalTools components
+* Add schema description for layout files: [layout.rng](../layouts/layout.rng)
+* Add validation script for layout files:<br>
+  Call `php maintenance/validateLayout.php <layout.xml>`
+* Add composer scripts: test, phpunit, build
+* Add JS linting for better code quality
+
+Fixes:
+* Javascript modules were not loading in MW 1.28+
+* Logo: Link to main page when *addLink* attribute is not present
+
 ### Chameleon 1.4
 
 Released on 20-Sep-2016
 
 Changes:
-* Logo: add addLink attribute to Logo component
+* Logo: add *addLink* attribute to Logo component
 
 Fixes:
 * Restore "Edit with form" link for Semantic Forms 3.5 and later

--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -245,6 +245,12 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 		<attribute name="type">
 			<value>PersonalTools</value>
 		</attribute>
+
+		<optional>
+			<attribute name="hideNewtalkNotifier" a:defaultValue="no">
+				<ref name="BoolValues"/>
+			</attribute>
+		</optional>
 	</define>
 
 	<define name="Component" combine="choice">

--- a/layouts/standard.xml
+++ b/layouts/standard.xml
@@ -33,7 +33,8 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 
 				<row>
 					<cell span="12">
-						<component type="PersonalTools" class="pull-right"/>
+						<component type="PersonalTools" hideNewtalkNotifier="yes" class="pull-right"/>
+						<component type="NewtalkNotifier" class="pull-right"/>
 					</cell>
 				</row>
 

--- a/maintenance/validateLayout.php
+++ b/maintenance/validateLayout.php
@@ -83,7 +83,7 @@ function validateFile( $filename ) {
 	$xml = new DOMDocument();
 	$xml->load( $filename );
 
-	if ( !$xml->relaxNGValidate( '../layouts/layout.rng' ) ) {
+	if ( !$xml->relaxNGValidate( __DIR__ . '/../layouts/layout.rng' ) ) {
 		libxml_display_errors();
 	} else {
 		print "Ok!\n";

--- a/src/Components/MainContent.php
+++ b/src/Components/MainContent.php
@@ -4,7 +4,7 @@
  *
  * This file is part of the MediaWiki skin Chameleon.
  *
- * @copyright 2013 - 2014, Stephan Gambke
+ * @copyright 2013 - 2016, Stephan Gambke
  * @license   GNU General Public License, version 3 (or any later version)
  *
  * The Chameleon skin is free software: you can redistribute it and/or modify
@@ -29,12 +29,7 @@ namespace Skins\Chameleon\Components;
 use Skins\Chameleon\IdRegistry;
 
 /**
- * The NavbarHorizontal class.
- *
- * A horizontal navbar containing the sidebar items.
- * Does not include standard items (toolbox, search, language links). They need to be added to the page elsewhere
- *
- * The navbar is a list of lists wrapped in a nav element: <nav role="navigation" id="p-navbar" >
+ * The MainContent class.
  *
  * @author Stephan Gambke
  * @since 1.0
@@ -110,7 +105,9 @@ class MainContent extends Component {
 				$this->indent() . $idRegistry->element( 'div', array( 'id' => 'contentSub2', 'class' => 'small' ), $skintemplate->get( 'undelete' ) );
 		}
 
-		// TODO: Do we need this? Seems to be an accessibility thing. It's used in vector to jump to the nav wich is at the bottom of the document, but our nav is usually at the top
+		// TODO: Do we need this? Seems to be an accessibility thing. It's used
+		// in vector to jump to the nav which is at the bottom of the document,
+		// but our nav is usually at the top
 		$ret .= $idRegistry->element( 'div', array( 'id' => 'jump-to-nav', 'class' => 'mw-jump' ),
 			$skintemplate->getMsg( 'jumpto' )->escaped() . '<a href="#mw-navigation">' . $skintemplate->getMsg( 'jumptonavigation' )->escaped() . '</a>' .
 			$skintemplate->getMsg( 'comma-separator' )->escaped() . '<a href="#p-search">' . $skintemplate->getMsg( 'jumptosearch' )->escaped() . '</a>'
@@ -140,7 +137,7 @@ class MainContent extends Component {
 		// TODO: Category links should be a separate component, but
 		// * dataAfterContent should come after the the category links.
 		// * only one extension is known to use it dataAfterContent and it is geared specifically towards MonoBook
-		// => provide an attribut hideCatLinks for the XML and -if present- hide category links and assume somebody knows what they are doing
+		// => provide an attribute hideCatLinks for the XML and -if present- hide category links and assume somebody knows what they are doing
 		return
 			$this->indent() . '<!-- category links -->' .
 			$this->indent() . $this->getSkinTemplate()->get( 'catlinks' );

--- a/src/Components/PersonalTools.php
+++ b/src/Components/PersonalTools.php
@@ -47,10 +47,6 @@ class PersonalTools extends Component {
 		$ret = $this->indent() . '<!-- personal tools -->' .
 			   $this->indent() . '<div class="p-personal ' . $this->getClassString() . '" id="p-personal" >';
 
-		// include message to a user about new messages on their talkpage
-		// TODO: make including the NewTalkNotifier dependent on an option (PREPEND, APPEND, OFF)
-		$newtalkNotifier = new NewtalkNotifier( $this->getSkinTemplate(), null, $this->getIndent() + 2 );
-
 		$ret .= $this->indent( 1 ) . '<ul class="p-personal-tools list-inline pull-right" >';
 
 		$this->indent( 1 );
@@ -61,11 +57,27 @@ class PersonalTools extends Component {
 		}
 
 		$ret .= $this->indent( -1 ) . '</ul>' .
-				$this->indent() . '<div class="newtalk-notifier">' . $newtalkNotifier->getHtml() .
-				$this->indent() . '</div>' .
-				$this->indent( -1 ) . '</div>' . "\n";
+			$this->indent( -1 ) . '</div>' . "\n";
+
+		$ret .= $this->getNewtalkNotifier( $ret );
 
 		return $ret;
+	}
+
+	/**
+	 * @return string
+	 */
+	private function getNewtalkNotifier() {
+
+		if ( $this->getDomElement() !== null && filter_var( $this->getDomElement()->getAttribute( 'hideNewtalkNotifier' ), FILTER_VALIDATE_BOOLEAN ) ) {
+			return '';
+		}
+
+		// include message to a user about new messages on their talkpage
+		$newtalkNotifier = new NewtalkNotifier( $this->getSkinTemplate(), null, $this->getIndent() + 2 );
+
+		return $this->indent() . '<div class="newtalk-notifier pull-right">' . $newtalkNotifier->getHtml() .
+			$this->indent() . '</div>';
 	}
 
 }


### PR DESCRIPTION
The attribute was introduced to keep backwards compatibility. If the
PersonalTools component is used, it is recommended to always set this attribute
to yes and use an independent NewtalkNotifier component.

The standard layout uses this now.

hideNewtalkNotifier:
* Already deprecated.
* Allowed values: Boolean (yes|no)
* Default: no
* Optional.

If set the newtalk notifier will not be shown.
This attribute has no effect when used inside the NavbarHorizontal component.

Also: Fix validateLayout.php to work from any directory.