### PR TITLE
NavbarHorizontal: Allow custom types and classes for Navbar elements

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ Changes:
 * Replace [jquery-sticky](https://github.com/garand/sticky) by
   [sticky-kit](http://leafo.net/sticky-kit/)
 * Use sticky for the navbar of the fixedhead layout
+* NavbarHorizontal: Allow custom types and classes for Navbar elements
 * PersonalTools: Add attribute *hideNewtalkNotifier*
 * Standard layout: Use separate NewtalkNotifier and PersonalTools components
 * Add schema description for layout files: [layout.rng](../layouts/layout.rng)

--- a/src/Components/NavbarHorizontal.php
+++ b/src/Components/NavbarHorizontal.php
@@ -209,6 +209,7 @@ class NavbarHorizontal extends Component {
 	 * @return string
 	 */
 	protected function buildNavBarElementFromDomElement( $node ) {
+
 		switch ( $node->getAttribute( 'type' ) ) {
 			case 'Logo':
 				$html = $this->getLogo( $node );
@@ -229,8 +230,19 @@ class NavbarHorizontal extends Component {
 				$html = $this->getMenu( $node );
 				break;
 			default:
-				$html = '';
+				$html = $this->buildNavBarElementFromComponentClass( $node );
 		}
+		return $html;
+	}
+
+	/**
+	 * @param $node
+	 *
+	 * @return string
+	 */
+	protected function buildNavBarElementFromComponentClass( $node ) {
+		$component = $this->getSkin()->getComponentFactory()->getComponent( $node, $this->getIndent() );
+		$html      = '<ul class="nav navbar-nav ' . $node->getAttribute( 'type' ) . '">' . $component->getHtml() . "</ul>\n";
 		return $html;
 	}
 
@@ -246,7 +258,6 @@ class NavbarHorizontal extends Component {
 		$logo = new Logo( $this->getSkinTemplate(), $domElement, $this->getIndent() );
 		$logo->addClasses( 'navbar-brand' );
 
-//        return \Html::rawElement( 'li', array(), $logo->getHtml() );
 		return $logo->getHtml();
 	}
 


### PR DESCRIPTION
In case an unknown component is encountered in its XML layout description,
NavbarHorizontal tries to find and use a component class in the
Skins\Chameleon\Components\Component namespace to format the component.