### PR TITLE
D groenewegen patch 1

### DIFF
--- a/resources/styles/screen.less
+++ b/resources/styles/screen.less
@@ -127,11 +127,6 @@ html {
 	}
 }
 
-/* Fix to prevent mw-body ul from overriding padding */
-.list-inline, .mw-body ul.list-inline {
-	padding-left:0px;
-}
-
 /* have to insert id based rule here to over-rule MW core's shared.css */
 #toc ul {
 	margin-left: 0.5em;
@@ -418,34 +413,11 @@ table.mw-recentchanges-table {
 	h1, h2, h3, h4, h5, h6 {
 		>span.mw-headline:before {
 			content: "";
-			display: block;
+			display: inline-block;
 			height: @navbar-height;
 			margin-top: 0-@navbar-height;
 		}
 	}
-}
-
-/* Fix for interference from mw-headline : https://www.mediawiki.org/wiki/Topic:Tpnbsxhvqcwb890x */
-
-.layout-fixedhead h1 > span.mw-headline::before, 
-.layout-stickyhead h1 > span.mw-headline::before, 
-.layout-clean h1 > span.mw-headline::before,
-.layout-fixedhead h2 > span.mw-headline::before, 
-.layout-stickyhead h2 > span.mw-headline::before, 
-.layout-clean h2 > span.mw-headline::before,
-.layout-fixedhead h3 > span.mw-headline::before, 
-.layout-stickyhead h3 > span.mw-headline::before, 
-.layout-clean h3 > span.mw-headline::before,
-.layout-fixedhead h4 > span.mw-headline::before, 
-.layout-stickyhead h4 > span.mw-headline::before, 
-.layout-clean h4 > span.mw-headline::before,
-.layout-fixedhead h5 > span.mw-headline::before, 
-.layout-stickyhead h5 > span.mw-headline::before, 
-.layout-clean h5 > span.mw-headline::before,
-.layout-fixedhead h6 > span.mw-headline::before, 
-.layout-stickyhead h6 > span.mw-headline::before, 
-.layout-clean h6 > span.mw-headline::before {
-    display: inline-block;
 }
 
 .mw-headline-anchor {

--- a/resources/styles/screen.less
+++ b/resources/styles/screen.less
@@ -257,6 +257,10 @@ a.new, #p-personal a.new {
 	ol, ul {
 		padding-left: @list-level-indent;
 		margin: 0;
+		
+		.list-inline {
+			.list-inline;
+		}
 
 		ul {
 			.bullet( @list-bullet-color, @list-bullet-size*.9);

--- a/resources/styles/screen.less
+++ b/resources/styles/screen.less
@@ -420,6 +420,29 @@ table.mw-recentchanges-table {
 	}
 }
 
+/* Fix for interference from mw-headline : https://www.mediawiki.org/wiki/Topic:Tpnbsxhvqcwb890x */
+
+.layout-fixedhead h1 > span.mw-headline::before, 
+.layout-stickyhead h1 > span.mw-headline::before, 
+.layout-clean h1 > span.mw-headline::before,
+.layout-fixedhead h2 > span.mw-headline::before, 
+.layout-stickyhead h2 > span.mw-headline::before, 
+.layout-clean h2 > span.mw-headline::before,
+.layout-fixedhead h3 > span.mw-headline::before, 
+.layout-stickyhead h3 > span.mw-headline::before, 
+.layout-clean h3 > span.mw-headline::before,
+.layout-fixedhead h4 > span.mw-headline::before, 
+.layout-stickyhead h4 > span.mw-headline::before, 
+.layout-clean h4 > span.mw-headline::before,
+.layout-fixedhead h5 > span.mw-headline::before, 
+.layout-stickyhead h5 > span.mw-headline::before, 
+.layout-clean h5 > span.mw-headline::before,
+.layout-fixedhead h6 > span.mw-headline::before, 
+.layout-stickyhead h6 > span.mw-headline::before, 
+.layout-clean h6 > span.mw-headline::before {
+    display: inline-block;
+}
+
 .mw-headline-anchor {
 	display: none;
 }

--- a/resources/styles/screen.less
+++ b/resources/styles/screen.less
@@ -127,6 +127,11 @@ html {
 	}
 }
 
+/* Fix to prevent mw-body ul from overriding padding */
+.list-inline, .mw-body ul.list-inline {
+	padding-left:0px;
+}
+
 /* have to insert id based rule here to over-rule MW core's shared.css */
 #toc ul {
 	margin-left: 0.5em;


### PR DESCRIPTION
Just two (minor) fixes where MediaWiki's native styles (mw-headline and mw-body) seem to interfere with Bootstrap styles. 
