### PR TITLE
Allow 'buttons` attribute for Searchbar component description

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -655,6 +655,13 @@ The search bar.
   
   The class (or classes) that should be assigned to the top-level html element
   of this component.
+  
+* `buttons`:
+  * Allowed values: String (`search`|`go`|`search go`)
+  * Default: `search go`
+  * Optional.
+  
+  The buttons that should be shown with the search bar.
 
 #### Allowed Parent Elements:
 * [Structure](#structure)

--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -2,7 +2,7 @@
 <!--
 This file is part of the MediaWiki skin Chameleon.
 
-@copyright 2013 - 2016, Stephan Gambke
+@copyright 2013 - 2017, Stephan Gambke
 @license   GNU General Public License, version 3 (or any later version)
 
 The Chameleon skin is free software: you can redistribute it and/or modify it
@@ -31,7 +31,8 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 
 	<a:documentation>
 		Schema for Chameleon layout files
-		Copyright 2013 - 2016, Stephan Gambke
+		Version 1.1
+		Copyright 2013 - 2017, Stephan Gambke
 		GNU General Public License, version 3 (or any later version)
 	</a:documentation>
 
@@ -275,6 +276,16 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 		<attribute name="type">
 			<value>SearchBar</value>
 		</attribute>
+
+		<optional>
+			<attribute name="buttons" a:defaultValue="search go">
+				<choice>
+					<value>search</value>
+					<value>go</value>
+					<value>search go</value>
+				</choice>
+			</attribute>
+		</optional>
 	</define>
 
 	<define name="Component" combine="choice">

--- a/src/Components/NavbarHorizontal/SearchBar.php
+++ b/src/Components/NavbarHorizontal/SearchBar.php
@@ -27,7 +27,7 @@
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
 use Skins\Chameleon\Components\Component;
-use Skins\Chameleon\Components\SearchBar as GenSearchBar;
+use Skins\Chameleon\Components\SearchBar as GenericSearchBar;
 
 /**
  * The NavbarHorizontal\PersonalTools class.
@@ -45,7 +45,7 @@ class SearchBar extends Component {
 	 */
 	public function getHtml() {
 
-		$search = new GenSearchBar( $this->getSkinTemplate(), $this->getDomElement(), $this->getIndent() );
+		$search = new GenericSearchBar( $this->getSkinTemplate(), $this->getDomElement(), $this->getIndent() );
 		$search->addClasses( 'navbar-form' );
 
 		return $search->getHtml();

--- a/src/Components/SearchBar.php
+++ b/src/Components/SearchBar.php
@@ -117,13 +117,13 @@ class SearchBar extends Component {
 
 		if ( $this->shouldShowButton( $button ) ) {
 
-			$buttonAttrs = [
+			$buttonAttrs = array(
 				'value' => $this->getSkinTemplate()->translator->translate( $valueAttr ),
 				'id' => IdRegistry::getRegistry()->getId( $idAttr ),
 				'name' => $nameAttr,
 				'type' => 'submit',
 				'class' => $idAttr . ' btn btn-default'
-			];
+			);
 
 			$buttonAttrs = array_merge(
 				$buttonAttrs,

--- a/src/Components/SearchBar.php
+++ b/src/Components/SearchBar.php
@@ -65,9 +65,13 @@ class SearchBar extends Component {
 			$this->indent( 1 ) . '<input type="hidden" name="title" value="' . $this->getSkinTemplate()->data[ 'searchtitle' ] . '" />' .
 			$this->indent() . '<div class="input-group">' .
 			$this->indent( 1 ) . $this->getSkinTemplate()->makeSearchInput( array( 'id' => IdRegistry::getRegistry()->getId( 'searchInput' ), 'type' => 'text', 'class' => 'form-control' ) ) .
-			$this->indent() . '<div class="input-group-btn">' .
-			$this->indent( 1 ) . $this->getSearchButton( 'go' ) .
-			$this->indent( 0 ) . $this->getSearchButton( 'fulltext' ) .
+			$this->indent() . '<div class="input-group-btn">';
+
+		$this->indent( 1 );
+
+		$ret .=
+			$this->getGoButton() .
+			$this->getSearchButton() .
 			$this->indent( -1 ) . '</div>' .
 			$this->indent( -1 ) . '</div>' .
 			$this->indent( -1 ) . '</form>' .
@@ -77,46 +81,64 @@ class SearchBar extends Component {
 	}
 
 	/**
-	 * This method basically replicates SkinTemplate::makeSearchButton, but uses buttons instead of inputs to ensure
-	 * proper styling by Bootstrap
-	 *
-	 * @param string $mode 'go' or 'fulltext', optional, default='fulltext'
-	 *
 	 * @return string
 	 */
-	private function getSearchButton( $mode = 'fulltext' ) {
+	private function getGoButton() {
 
-		if ( $mode === 'go' ) {
+		$valueAttr = 'searcharticle';
+		$idAttr = 'searchGoButton';
+		$nameAttr = 'go';
+		$glyphicon = ( $this->getAttribute( 'buttons' ) === 'go' ? 'search' : 'share-alt' );
 
-			$buttonAttrs = array(
-				'value' => $this->getSkinTemplate()->translator->translate( 'searcharticle' ),
-				'id'    => IdRegistry::getRegistry()->getId( 'searchGoButton' ),
-				'name'  => 'go',
-			);
-
-			$glyphicon = 'share-alt';
-
-		} else {
-
-			$buttonAttrs = array(
-				'value' => $this->getSkinTemplate()->translator->translate( 'searchbutton' ),
-				'id'    => IdRegistry::getRegistry()->getId( 'mw-searchButton' ),
-				'name'  => 'fulltext',
-			);
-
-			$glyphicon = 'search';
-		}
-
-		$buttonAttrs = array_merge(
-			$buttonAttrs,
-			Linker::tooltipAndAccesskeyAttribs( "search-$mode" ),
-			array(
-				 'type'  => 'submit',
-				 'class' => $buttonAttrs[ 'id' ] . ' btn btn-default'
-			)
-		);
-
-		return \Html::rawElement( 'button', $buttonAttrs, '<span class="glyphicon glyphicon-' . $glyphicon . '"></span>' );
+		return $this->getButton( 'go', $valueAttr, $idAttr, $nameAttr, $glyphicon );
 	}
 
+	/**
+	 * @return string
+	 */
+	private function getSearchButton() {
+
+		$valueAttr = 'searchbutton';
+		$idAttr = 'mw-searchButton';
+		$nameAttr = 'fulltext';
+		$glyphicon = 'search';
+
+		return $this->getButton( 'search', $valueAttr, $idAttr, $nameAttr, $glyphicon );
+	}
+
+	/**
+	 * @param $valueAttr
+	 * @param $idAttr
+	 * @param $nameAttr
+	 * @param $glyphicon
+	 * @return string
+	 */
+	private function getButton( $button, $valueAttr, $idAttr, $nameAttr, $glyphicon ) {
+
+		if ( $this->shouldShowButton( $button ) ) {
+
+			$buttonAttrs = [
+				'value' => $this->getSkinTemplate()->translator->translate( $valueAttr ),
+				'id' => IdRegistry::getRegistry()->getId( $idAttr ),
+				'name' => $nameAttr,
+				'type' => 'submit',
+				'class' => $idAttr . ' btn btn-default'
+			];
+
+			$buttonAttrs = array_merge(
+				$buttonAttrs,
+				Linker::tooltipAndAccesskeyAttribs( "search-$nameAttr" )
+			);
+
+			return $this->indent() . \Html::rawElement( 'button', $buttonAttrs, '<span class="glyphicon glyphicon-' . $glyphicon . '"></span>' );
+		}
+
+		return '';
+	}
+
+	private function shouldShowButton( $button ) {
+		$buttonsAttribute = $this->getAttribute( 'buttons' );
+		return $button === 'go' && $buttonsAttribute !== 'search' ||
+			$button === 'search' && $buttonsAttribute !== 'go';
+	}
 }


### PR DESCRIPTION
* Allowed values: String (`search`|`go`|`search go`)
* Default: `search go`
* Optional.

Fixes #18