### PR TITLE
legal: Remove misleading/incorrect text about bundling

### DIFF
--- a/docs/legal.md
+++ b/docs/legal.md
@@ -57,8 +57,7 @@ Some cases I can think of:
   the skin and all its dependencies I would have to more carefully check license
   compatibility.
 * Chameleon itself might become part of a tarball, e.g. some pre-build,
-  pre-configured wiki for I don't know what purpose. Right now MW is GPL2
-  licensed which makes it incompatible for bundling with Chameleon at GPL3+.
+  pre-configured wiki for I don't know what purpose.
 * Parts of the skin might actually be included in MW core. E.g. there is a
   menu-building class proposed for MediaWiki, that would have a functionality
   similar to what's contained in Chameleon. See


### PR DESCRIPTION
MediaWiki is licensed as GPL v2 or later, so including any GPL v3 projects
is totally OK, since you're just using it under the terms of v3. And since
MediaWiki depends on and bundles Apache 2.0 projects (which is only
compatible with GPL v3), MediaWiki itself is effectively GPL v3. So there's
no problem with bundling GPL v3 projects with MediaWiki, and in fact the
1.31 release will contain GPL v3 or later code in the tarball.